### PR TITLE
Member, Company 도메인 엔티티 생성

### DIFF
--- a/growthmate-core/src/main/java/com/growup/growthmate/company/domain/Company.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/company/domain/Company.java
@@ -1,0 +1,17 @@
+package com.growup.growthmate.company.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Company {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "company_id")
+    private Long id;
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/member/domain/Member.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/member/domain/Member.java
@@ -1,0 +1,17 @@
+package com.growup.growthmate.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+}

--- a/growthmate-core/src/main/resources/db/migration/V1__create-member.sql
+++ b/growthmate-core/src/main/resources/db/migration/V1__create-member.sql
@@ -1,0 +1,5 @@
+CREATE TABLE member
+(
+    member_id BIGINT AUTO_INCREMENT NOT NULL,
+    CONSTRAINT pk_member PRIMARY KEY (member_id)
+);

--- a/growthmate-core/src/main/resources/db/migration/V1__create-member.sql
+++ b/growthmate-core/src/main/resources/db/migration/V1__create-member.sql
@@ -1,5 +1,0 @@
-CREATE TABLE member
-(
-    member_id BIGINT AUTO_INCREMENT NOT NULL,
-    CONSTRAINT pk_member PRIMARY KEY (member_id)
-);

--- a/growthmate-core/src/main/resources/db/migration/V1__init.sql
+++ b/growthmate-core/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,11 @@
+CREATE TABLE member
+(
+    member_id BIGINT AUTO_INCREMENT NOT NULL,
+    CONSTRAINT pk_member PRIMARY KEY (member_id)
+);
+
+CREATE TABLE company
+(
+    company_id BIGINT AUTO_INCREMENT NOT NULL,
+    CONSTRAINT pk_company PRIMARY KEY (company_id)
+);


### PR DESCRIPTION
커뮤니티 기능을 개발하려면 `Member`와 `Company` 도메인이 필요합니다. (테이블도 필요) `Member`의 경우 인증 기능을 만들 때도 필요할거라 `Member` 도메인을 생성한 PR을 먼저 날립니다. 이 PR이 머지된 이후로 각자 이 `Member`를 사용하면서 본격적인 개발을 시작하면 될 것 같습니다!

++ 추가적으로 저희가 공통적으로 사용해야할 클래스가 있을까요? 이 PR에서 딱 정리하고 가야할 것 같습니다. 안그러면 충돌이 발생할 것 같아요.
