### PR TITLE
댓글 작성, 수정, 삭제 API 구현

### DIFF
--- a/growthmate-api/src/main/java/com/growup/growthmate/command/api/CommentV1Controller.java
+++ b/growthmate-api/src/main/java/com/growup/growthmate/command/api/CommentV1Controller.java
@@ -1,0 +1,29 @@
+package com.growup.growthmate.command.api;
+
+import com.growup.growthmate.LoginMember;
+import com.growup.growthmate.command.dto.CommentCreateRequest;
+import com.growup.growthmate.comment.application.CommentService;
+import com.growup.growthmate.comment.dto.CommentCreateCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class CommentV1Controller {
+
+    private final CommentService commentService;
+
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<Void> createComment(@PathVariable Long postId,
+                                              @RequestBody CommentCreateRequest request,
+                                              LoginMember loginMember) {
+        CommentCreateCommand command = new CommentCreateCommand(postId, request.content(), loginMember.id());
+        Long commentId = commentService.create(command);
+        return ResponseEntity.created(URI.create("/comments/" + commentId))
+                .build();
+    }
+}

--- a/growthmate-api/src/main/java/com/growup/growthmate/command/api/CommentV1Controller.java
+++ b/growthmate-api/src/main/java/com/growup/growthmate/command/api/CommentV1Controller.java
@@ -5,6 +5,7 @@ import com.growup.growthmate.command.dto.CommentCreateRequest;
 import com.growup.growthmate.command.dto.CommentUpdateRequest;
 import com.growup.growthmate.comment.application.CommentService;
 import com.growup.growthmate.comment.dto.CommentCreateCommand;
+import com.growup.growthmate.comment.dto.CommentDeleteCommand;
 import com.growup.growthmate.comment.dto.CommentUpdateCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +36,14 @@ public class CommentV1Controller {
                                               LoginMember loginMember) {
         CommentUpdateCommand command = new CommentUpdateCommand(commentId, request.content(), loginMember.id());
         commentService.update(command);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId,
+                                              LoginMember loginMember) {
+        CommentDeleteCommand command = new CommentDeleteCommand(commentId, loginMember.id());
+        commentService.delete(command);
         return ResponseEntity.noContent().build();
     }
 }

--- a/growthmate-api/src/main/java/com/growup/growthmate/command/api/CommentV1Controller.java
+++ b/growthmate-api/src/main/java/com/growup/growthmate/command/api/CommentV1Controller.java
@@ -2,8 +2,10 @@ package com.growup.growthmate.command.api;
 
 import com.growup.growthmate.LoginMember;
 import com.growup.growthmate.command.dto.CommentCreateRequest;
+import com.growup.growthmate.command.dto.CommentUpdateRequest;
 import com.growup.growthmate.comment.application.CommentService;
 import com.growup.growthmate.comment.dto.CommentCreateCommand;
+import com.growup.growthmate.comment.dto.CommentUpdateCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,5 +27,14 @@ public class CommentV1Controller {
         Long commentId = commentService.create(command);
         return ResponseEntity.created(URI.create("/comments/" + commentId))
                 .build();
+    }
+
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<Void> updateComment(@PathVariable Long commentId,
+                                              @RequestBody CommentUpdateRequest request,
+                                              LoginMember loginMember) {
+        CommentUpdateCommand command = new CommentUpdateCommand(commentId, request.content(), loginMember.id());
+        commentService.update(command);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/growthmate-api/src/main/java/com/growup/growthmate/command/dto/CommentCreateRequest.java
+++ b/growthmate-api/src/main/java/com/growup/growthmate/command/dto/CommentCreateRequest.java
@@ -1,0 +1,4 @@
+package com.growup.growthmate.command.dto;
+
+public record CommentCreateRequest(String content) {
+}

--- a/growthmate-api/src/main/java/com/growup/growthmate/command/dto/CommentUpdateRequest.java
+++ b/growthmate-api/src/main/java/com/growup/growthmate/command/dto/CommentUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.growup.growthmate.command.dto;
+
+public record CommentUpdateRequest(String content) {
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
@@ -1,10 +1,14 @@
 package com.growup.growthmate.comment.application;
 
+import com.growup.growthmate.BusinessException;
 import com.growup.growthmate.comment.domain.Comment;
 import com.growup.growthmate.comment.domain.CommentRepository;
+import com.growup.growthmate.comment.domain.value.CommentContent;
 import com.growup.growthmate.comment.dto.CommentCreateCommand;
 import com.growup.growthmate.comment.dto.CommentMapper;
 import com.growup.growthmate.comment.dto.CommentUpdateCommand;
+import com.growup.growthmate.comment.exception.CommentException;
+import com.growup.growthmate.post.domain.value.WriterId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +27,21 @@ public class CommentService {
     }
 
     public void update(CommentUpdateCommand command) {
+        Comment comment = getComment(command);
+        validateWriter(command, comment);
+        comment.updateContent(new CommentContent(command.content()));
+    }
 
+    private Comment getComment(CommentUpdateCommand command) {
+        CommentException exception = CommentException.NOT_FOUND_COMMENT;
+        return commentRepository.findById(command.commentId())
+                .orElseThrow(() -> new BusinessException(exception.getHttpStatusCode(), exception.getMessage()));
+    }
+
+    private void validateWriter(CommentUpdateCommand command, Comment comment) {
+        CommentException exception = CommentException.UNAUTHORIZED_WRITER;
+        if (!comment.isSameWriterId(new WriterId(command.writerId()))) {
+            throw new BusinessException(exception.getHttpStatusCode(), exception.getMessage());
+        }
     }
 }

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
@@ -1,6 +1,9 @@
 package com.growup.growthmate.comment.application;
 
+import com.growup.growthmate.comment.domain.Comment;
+import com.growup.growthmate.comment.domain.CommentRepository;
 import com.growup.growthmate.comment.dto.CommentCreateCommand;
+import com.growup.growthmate.comment.dto.CommentMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,7 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CommentService {
 
+    private final CommentRepository commentRepository;
+
     public Long create(CommentCreateCommand command) {
-        return null;
+        Comment comment = CommentMapper.toDomain(command);
+        Comment saved = commentRepository.save(comment);
+        return saved.getId();
     }
 }

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
@@ -4,6 +4,7 @@ import com.growup.growthmate.comment.domain.Comment;
 import com.growup.growthmate.comment.domain.CommentRepository;
 import com.growup.growthmate.comment.dto.CommentCreateCommand;
 import com.growup.growthmate.comment.dto.CommentMapper;
+import com.growup.growthmate.comment.dto.CommentUpdateCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,5 +20,9 @@ public class CommentService {
         Comment comment = CommentMapper.toDomain(command);
         Comment saved = commentRepository.save(comment);
         return saved.getId();
+    }
+
+    public void update(CommentUpdateCommand command) {
+
     }
 }

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
@@ -28,25 +28,27 @@ public class CommentService {
     }
 
     public void update(CommentUpdateCommand command) {
-        Comment comment = getComment(command);
-        validateWriter(command, comment);
+        Comment comment = getComment(command.commentId());
+        validateWriter(comment, command.writerId());
         comment.updateContent(new CommentContent(command.content()));
     }
 
-    private Comment getComment(CommentUpdateCommand command) {
+    public void delete(CommentDeleteCommand command) {
+        Comment comment = getComment(command.commentId());
+        validateWriter(comment, command.writerId());
+        commentRepository.delete(comment);
+    }
+
+    private Comment getComment(Long commentId) {
         CommentException exception = CommentException.NOT_FOUND_COMMENT;
-        return commentRepository.findById(command.commentId())
+        return commentRepository.findById(commentId)
                 .orElseThrow(() -> new BusinessException(exception.getHttpStatusCode(), exception.getMessage()));
     }
 
-    private void validateWriter(CommentUpdateCommand command, Comment comment) {
+    private void validateWriter(Comment comment, Long writerId) {
         CommentException exception = CommentException.UNAUTHORIZED_WRITER;
-        if (!comment.isSameWriterId(new WriterId(command.writerId()))) {
+        if (!comment.isSameWriterId(new WriterId(writerId))) {
             throw new BusinessException(exception.getHttpStatusCode(), exception.getMessage());
         }
-    }
-
-    public void delete(CommentDeleteCommand command) {
-
     }
 }

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
@@ -5,6 +5,7 @@ import com.growup.growthmate.comment.domain.Comment;
 import com.growup.growthmate.comment.domain.CommentRepository;
 import com.growup.growthmate.comment.domain.value.CommentContent;
 import com.growup.growthmate.comment.dto.CommentCreateCommand;
+import com.growup.growthmate.comment.dto.CommentDeleteCommand;
 import com.growup.growthmate.comment.dto.CommentMapper;
 import com.growup.growthmate.comment.dto.CommentUpdateCommand;
 import com.growup.growthmate.comment.exception.CommentException;
@@ -43,5 +44,9 @@ public class CommentService {
         if (!comment.isSameWriterId(new WriterId(command.writerId()))) {
             throw new BusinessException(exception.getHttpStatusCode(), exception.getMessage());
         }
+    }
+
+    public void delete(CommentDeleteCommand command) {
+
     }
 }

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/application/CommentService.java
@@ -1,0 +1,16 @@
+package com.growup.growthmate.comment.application;
+
+import com.growup.growthmate.comment.dto.CommentCreateCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentService {
+
+    public Long create(CommentCreateCommand command) {
+        return null;
+    }
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/Comment.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/Comment.java
@@ -32,4 +32,12 @@ public class Comment {
         this.writerId = writerId;
         this.content = content;
     }
+
+    public void updateContent(CommentContent content) {
+        this.content = content;
+    }
+
+    public boolean isSameWriterId(WriterId writerId) {
+        return this.writerId.equals(writerId);
+    }
 }

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/Comment.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/Comment.java
@@ -7,10 +7,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@SQLDelete(sql = "UPDATE comment set is_deleted = 1 where comment_id = ?")
+@Where(clause = "is_deleted = 0")
 public class Comment {
 
     @Id
@@ -27,10 +31,14 @@ public class Comment {
     @Embedded
     private CommentContent content;
 
+    @Column(nullable = false)
+    private boolean isDeleted;
+
     public Comment(PostId postId, WriterId writerId, CommentContent content) {
         this.postId = postId;
         this.writerId = writerId;
         this.content = content;
+        this.isDeleted = false;
     }
 
     public void updateContent(CommentContent content) {

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/Comment.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/Comment.java
@@ -1,0 +1,35 @@
+package com.growup.growthmate.comment.domain;
+
+import com.growup.growthmate.comment.domain.value.CommentContent;
+import com.growup.growthmate.comment.domain.value.PostId;
+import com.growup.growthmate.post.domain.value.WriterId;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @Embedded
+    private PostId postId;
+
+    @Embedded
+    private WriterId writerId;
+
+    @Embedded
+    private CommentContent content;
+
+    public Comment(PostId postId, WriterId writerId, CommentContent content) {
+        this.postId = postId;
+        this.writerId = writerId;
+        this.content = content;
+    }
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/CommentRepository.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/CommentRepository.java
@@ -2,7 +2,11 @@ package com.growup.growthmate.comment.domain;
 
 import org.springframework.data.repository.Repository;
 
+import java.util.Optional;
+
 public interface CommentRepository extends Repository<Comment, Long> {
 
     Comment save(Comment comment);
+
+    Optional<Comment> findById(Long id);
 }

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/CommentRepository.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.growup.growthmate.comment.domain;
+
+import org.springframework.data.repository.Repository;
+
+public interface CommentRepository extends Repository<Comment, Long> {
+
+    Comment save(Comment comment);
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/CommentRepository.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/CommentRepository.java
@@ -9,4 +9,6 @@ public interface CommentRepository extends Repository<Comment, Long> {
     Comment save(Comment comment);
 
     Optional<Comment> findById(Long id);
+
+    void delete(Comment comment);
 }

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/value/CommentContent.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/value/CommentContent.java
@@ -1,5 +1,7 @@
 package com.growup.growthmate.comment.domain.value;
 
+import com.growup.growthmate.BusinessException;
+import com.growup.growthmate.comment.exception.CommentException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Lob;
@@ -19,6 +21,14 @@ public class CommentContent {
     private String value;
 
     public CommentContent(String value) {
+        validateContentLength(value);
         this.value = value;
+    }
+
+    private void validateContentLength(String value) {
+        if (value == null || value.isBlank()) {
+            CommentException exception = CommentException.INVALID_CONTENT;
+            throw new BusinessException(exception.getHttpStatusCode(), exception.getMessage());
+        }
     }
 }

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/value/CommentContent.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/value/CommentContent.java
@@ -1,0 +1,24 @@
+package com.growup.growthmate.comment.domain.value;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+@Getter
+public class CommentContent {
+
+    @Column(name = "content", nullable = false)
+    @Lob
+    private String value;
+
+    public CommentContent(String value) {
+        this.value = value;
+    }
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/value/PostId.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/domain/value/PostId.java
@@ -1,0 +1,17 @@
+package com.growup.growthmate.comment.domain.value;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+@Getter
+public class PostId {
+
+    @Column(nullable = false, name = "post_id")
+    private Long value;
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/dto/CommentCreateCommand.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/dto/CommentCreateCommand.java
@@ -1,0 +1,4 @@
+package com.growup.growthmate.comment.dto;
+
+public record CommentCreateCommand(Long postId, String content, Long writerId) {
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/dto/CommentDeleteCommand.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/dto/CommentDeleteCommand.java
@@ -1,0 +1,4 @@
+package com.growup.growthmate.comment.dto;
+
+public record CommentDeleteCommand(Long commentId, Long writerId) {
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/dto/CommentMapper.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/dto/CommentMapper.java
@@ -1,0 +1,20 @@
+package com.growup.growthmate.comment.dto;
+
+import com.growup.growthmate.comment.domain.Comment;
+import com.growup.growthmate.comment.domain.value.CommentContent;
+import com.growup.growthmate.comment.domain.value.PostId;
+import com.growup.growthmate.post.domain.value.WriterId;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentMapper {
+
+    public static Comment toDomain(CommentCreateCommand command) {
+        return new Comment(
+                new PostId(command.postId()),
+                new WriterId(command.writerId()),
+                new CommentContent(command.content())
+        );
+    }
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/dto/CommentUpdateCommand.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/dto/CommentUpdateCommand.java
@@ -1,0 +1,4 @@
+package com.growup.growthmate.comment.dto;
+
+public record CommentUpdateCommand(Long commentId, String content, Long writerId) {
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/exception/CommentException.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/exception/CommentException.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 @Getter
 public enum CommentException {
 
-    INVALID_CONTENT(400, "댓글 내용은 공백이면 안됩니다.")
+    INVALID_CONTENT(400, "댓글 내용은 공백이면 안됩니다."),
+    NOT_FOUND_COMMENT(404, "존재하지 않는 댓글입니다."),
+    UNAUTHORIZED_WRITER(403, "댓글에 접근할 권한이 없습니다.")
 
     ;
 

--- a/growthmate-core/src/main/java/com/growup/growthmate/comment/exception/CommentException.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/comment/exception/CommentException.java
@@ -1,0 +1,19 @@
+package com.growup.growthmate.comment.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum CommentException {
+
+    INVALID_CONTENT(400, "댓글 내용은 공백이면 안됩니다.")
+
+    ;
+
+    private final int httpStatusCode;
+    private final String message;
+
+    CommentException(int httpStatusCode, String message) {
+        this.httpStatusCode = httpStatusCode;
+        this.message = message;
+    }
+}

--- a/growthmate-core/src/main/java/com/growup/growthmate/post/domain/value/PostContent.java
+++ b/growthmate-core/src/main/java/com/growup/growthmate/post/domain/value/PostContent.java
@@ -22,7 +22,7 @@ public class PostContent {
         this.value = value;
     }
 
-    private static void validateContentLength(String value) {
+    private void validateContentLength(String value) {
         if (value == null || value.isBlank()) {
             PostException exception = PostException.INVALID_CONTENT;
             throw new BusinessException(exception.getHttpStatusCode(), exception.getMessage());

--- a/growthmate-core/src/main/resources/db/migration/V1__init.sql
+++ b/growthmate-core/src/main/resources/db/migration/V1__init.sql
@@ -33,6 +33,7 @@ CREATE TABLE comment
     post_id    BIGINT                NOT NULL,
     member_id  BIGINT                NOT NULL,
     content    LONGTEXT              NOT NULL,
+    is_deleted BIT(1)                NOT NULL,
     CONSTRAINT pk_comment PRIMARY KEY (comment_id)
 );
 

--- a/growthmate-core/src/main/resources/db/migration/V1__init.sql
+++ b/growthmate-core/src/main/resources/db/migration/V1__init.sql
@@ -26,3 +26,18 @@ ALTER TABLE post
 
 ALTER TABLE post
     ADD CONSTRAINT FK_POST_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);
+
+CREATE TABLE comment
+(
+    comment_id BIGINT AUTO_INCREMENT NOT NULL,
+    post_id    BIGINT                NOT NULL,
+    member_id  BIGINT                NOT NULL,
+    content    LONGTEXT              NOT NULL,
+    CONSTRAINT pk_comment PRIMARY KEY (comment_id)
+);
+
+ALTER TABLE comment
+    ADD CONSTRAINT FK_COMMENT_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);
+
+ALTER TABLE comment
+    ADD CONSTRAINT FK_COMMENT_ON_POST FOREIGN KEY (post_id) REFERENCES post (post_id);

--- a/growthmate-core/src/test/java/com/growup/growthmate/comment/application/CommentServiceTest.java
+++ b/growthmate-core/src/test/java/com/growup/growthmate/comment/application/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.growup.growthmate.comment.application;
 import com.growup.growthmate.BusinessException;
 import com.growup.growthmate.comment.domain.Comment;
 import com.growup.growthmate.comment.dto.CommentCreateCommand;
+import com.growup.growthmate.comment.dto.CommentDeleteCommand;
 import com.growup.growthmate.comment.dto.CommentUpdateCommand;
 import com.growup.growthmate.comment.exception.CommentException;
 import com.growup.isolation.TestIsolation;
@@ -130,6 +131,34 @@ class CommentServiceTest {
 
             // when then
             assertThatThrownBy(() -> commentService.update(command))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(CommentException.UNAUTHORIZED_WRITER.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글을 삭제할 때")
+    class DeleteTest {
+        @Test
+        void 유효한_작성자면_삭제한다() {
+            // given
+            CommentDeleteCommand command = new CommentDeleteCommand(commentId, TEST_WRITER_ID);
+
+            // when
+            commentService.delete(command);
+
+            // then
+            Comment comment = entityManager.find(Comment.class, commentId);
+            assertThat(comment).isNull();
+        }
+
+        @Test
+        void 유효하지_않은_작성자면_예외가_발생한다() {
+            // given
+            CommentDeleteCommand command = new CommentDeleteCommand(commentId, 2L);
+
+            // when then
+            assertThatThrownBy(() -> commentService.delete(command))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(CommentException.UNAUTHORIZED_WRITER.getMessage());
         }

--- a/growthmate-core/src/test/java/com/growup/growthmate/comment/application/CommentServiceTest.java
+++ b/growthmate-core/src/test/java/com/growup/growthmate/comment/application/CommentServiceTest.java
@@ -1,0 +1,58 @@
+package com.growup.growthmate.comment.application;
+
+import com.growup.growthmate.comment.domain.Comment;
+import com.growup.growthmate.comment.dto.CommentCreateCommand;
+import com.growup.isolation.TestIsolation;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@TestIsolation
+class CommentServiceTest {
+
+    private static final Long TEST_WRITER_ID = 1L;
+    private static final Long TEST_POST_ID = 2L;
+    private static final String TEST_CONTENT = "이것은 댓글입니다.";
+
+    @Autowired
+    private CommentService commentService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Nested
+    @DisplayName("댓글을 생성할 때")
+    class CreateTest {
+
+        @Test
+        void 유효한_내용은_생성한다() {
+            // given
+            CommentCreateCommand command = new CommentCreateCommand(TEST_POST_ID, TEST_CONTENT, TEST_WRITER_ID);
+
+            // when
+            Long commentId = commentService.create(command);
+
+            // then
+            Comment comment = entityManager.find(Comment.class, commentId);
+            assertAll(
+                    () -> assertThat(comment.getId()).isNotNull(),
+                    () -> assertThat(comment.getPostId().getValue()).isEqualTo(TEST_POST_ID),
+                    () -> assertThat(comment.getWriterId().getValue()).isEqualTo(TEST_WRITER_ID),
+                    () -> assertThat(comment.getContent().getValue()).isEqualTo(TEST_CONTENT)
+            );
+        }
+
+        @Test
+        void 내용이_비어_있으면_예외가_발생한다() {
+
+        }
+    }
+}

--- a/growthmate-core/src/test/java/com/growup/growthmate/comment/application/CommentServiceTest.java
+++ b/growthmate-core/src/test/java/com/growup/growthmate/comment/application/CommentServiceTest.java
@@ -1,18 +1,23 @@
 package com.growup.growthmate.comment.application;
 
+import com.growup.growthmate.BusinessException;
 import com.growup.growthmate.comment.domain.Comment;
 import com.growup.growthmate.comment.dto.CommentCreateCommand;
+import com.growup.growthmate.comment.exception.CommentException;
 import com.growup.isolation.TestIsolation;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
 @TestIsolation
@@ -50,9 +55,16 @@ class CommentServiceTest {
             );
         }
 
-        @Test
-        void 내용이_비어_있으면_예외가_발생한다() {
+        @ParameterizedTest
+        @ValueSource(strings = {"", " "})
+        void 내용이_비어_있으면_예외가_발생한다(String blankContent) {
+            // given
+            CommentCreateCommand command = new CommentCreateCommand(TEST_POST_ID, blankContent, TEST_WRITER_ID);
 
+            // when then
+            assertThatThrownBy(() -> commentService.create(command))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(CommentException.INVALID_CONTENT.getMessage());
         }
     }
 }

--- a/growthmate-core/src/test/java/com/growup/growthmate/comment/domain/value/CommentContentTest.java
+++ b/growthmate-core/src/test/java/com/growup/growthmate/comment/domain/value/CommentContentTest.java
@@ -1,0 +1,29 @@
+package com.growup.growthmate.comment.domain.value;
+
+import com.growup.growthmate.BusinessException;
+import com.growup.growthmate.comment.exception.CommentException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CommentContentTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void 게시글_내용은_공백이면_안된다(String value) {
+        // when then
+        assertThatThrownBy(() -> new CommentContent(value))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(CommentException.INVALID_CONTENT.getMessage());
+    }
+
+    @Test
+    void 내용은_null이면_안된다() {
+        // when then
+        assertThatThrownBy(() -> new CommentContent(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(CommentException.INVALID_CONTENT.getMessage());
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
- 댓글 작성 api 구현
- 댓글 수정 api 구현
- 댓글 삭제 api 구현

## 📝 참고 사항
- 게시글 작성, 수정, 삭제랑 전체적으로 맥락이 비슷합니다.
- 조회 api는 '회원'쪽 정보도 필요하여 (게시글 조회시 작성자 이름을 보여준다던가 나의 게시글인지 표시한다던가) 인증 기능이 완료되어야 구현할 수 있을 것 같습니다.
- 구현하고 보니 '게시글'과 '댓글' 도메인과 서비스에 비슷하게 중복되는 코드가 보여 다음 PR은 중복 제거 리팩터링을 진행할까 생각 중입니다.
