### PR TITLE
엑셀 DB 반영 트러블 슈팅 및 엑셀 업로드 저장소 생성

### DIFF
--- a/.github/workflows/batch.yml
+++ b/.github/workflows/batch.yml
@@ -2,7 +2,7 @@ name: Batch module docker hub push
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ fix/sql-error ]
 
 jobs:
   deploy:

--- a/.github/workflows/batch.yml
+++ b/.github/workflows/batch.yml
@@ -2,7 +2,7 @@ name: Batch module docker hub push
 
 on:
   push:
-    branches: [ fix/sql-error ]
+    branches: [ develop ]
 
 jobs:
   deploy:

--- a/growthmate-batch/src/main/java/com/growup/growthmate/batch/CompanyBatch.java
+++ b/growthmate-batch/src/main/java/com/growup/growthmate/batch/CompanyBatch.java
@@ -44,6 +44,7 @@ public class CompanyBatch {
                 .reader(companyReader)
                 .processor(companyProcessor)
                 .writer(companyWriter)
+                .allowStartIfComplete(true)
                 .build();
     }
 

--- a/growthmate-batch/src/main/resources/application.yml
+++ b/growthmate-batch/src/main/resources/application.yml
@@ -9,6 +9,9 @@ spring:
     enabled: true
     baseline-on-migrate: true
     version: 1
+  batch:
+    jdbc:
+      initialize-schema: always
 
 ---
 spring:

--- a/growthmate-core/src/main/resources/db/migration/V3__company-update.sql
+++ b/growthmate-core/src/main/resources/db/migration/V3__company-update.sql
@@ -1,11 +1,11 @@
 ALTER TABLE company ADD CONSTRAINT comapny_name_unique UNIQUE (name);
 
-ALTER TABLE company MODIFY image_url LONGTEXT null;
-ALTER TABLE company MODIFY ceo null;
-ALTER TABLE company MODIFY scale null;
-ALTER TABLE company MODIFY business_type null;
-ALTER TABLE company MODIFY business null;
-ALTER TABLE company MODIFY establishment_date null;
-ALTER TABLE company MODIFY sales null;
-ALTER TABLE company MODIFY employee_number null;
-ALTER TABLE company MODIFY address null;
+ALTER TABLE company MODIFY COLUMN image_url LONGTEXT null;
+ALTER TABLE company MODIFY COLUMN ceo null;
+ALTER TABLE company MODIFY COLUMN scale null;
+ALTER TABLE company MODIFY COLUMN business_type null;
+ALTER TABLE company MODIFY COLUMN business null;
+ALTER TABLE company MODIFY COLUMN establishment_date null;
+ALTER TABLE company MODIFY COLUMN sales null;
+ALTER TABLE company MODIFY COLUMN employee_number null;
+ALTER TABLE company MODIFY COLUMN address null;

--- a/growthmate-core/src/main/resources/db/migration/V3__company-update.sql
+++ b/growthmate-core/src/main/resources/db/migration/V3__company-update.sql
@@ -1,11 +1,11 @@
 ALTER TABLE company ADD CONSTRAINT comapny_name_unique UNIQUE (name);
 
 ALTER TABLE company MODIFY COLUMN image_url LONGTEXT null;
-ALTER TABLE company MODIFY COLUMN ceo null;
-ALTER TABLE company MODIFY COLUMN scale null;
-ALTER TABLE company MODIFY COLUMN business_type null;
-ALTER TABLE company MODIFY COLUMN business null;
-ALTER TABLE company MODIFY COLUMN establishment_date null;
-ALTER TABLE company MODIFY COLUMN sales null;
-ALTER TABLE company MODIFY COLUMN employee_number null;
-ALTER TABLE company MODIFY COLUMN address null;
+ALTER TABLE company MODIFY COLUMN ceo VARCHAR(255) null;
+ALTER TABLE company MODIFY COLUMN scale VARCHAR(255) null;
+ALTER TABLE company MODIFY COLUMN business_type VARCHAR(255) null;
+ALTER TABLE company MODIFY COLUMN business VARCHAR(255) null;
+ALTER TABLE company MODIFY COLUMN establishment_date datetime null;
+ALTER TABLE company MODIFY COLUMN sales BIGINT null;
+ALTER TABLE company MODIFY COLUMN employee_number BIGINT null;
+ALTER TABLE company MODIFY COLUMN address VARCHAR(255) null;


### PR DESCRIPTION
## 📌 작업 내용
- V3 마이그레이션 파일 수정
  - mysql 문법이 잘못된 부분이 있어서 수정했습니다.
  - 엑셀 파일에 null이 많아서 DB도 null을 허용하도록 변경하였습니다.
- spring batch 메타 테이블 초기화 설정 추가
``` yml
spring:
  batch:
    jdbc:
      initialize-schema: always
```
- 엑셀 파일에서 타입 불일치로 인한 read가 실패할 경우 왜 실패했는지 로그 남기기 추가
- 완료 상태인 Step이더라도 재실행하도록 `.allowStartIfComplete(true)` 추가
  - 배치 작업이 파라미터는 없지만 실행될 때마다 재실행되어야 하기 때문에 설정해주었습니다.
- [엑셀 파일 업로드 저장소](https://github.com/HANIUM-GROWUP/data-integration-pipeline) 생성
  - 이 저장소도 확인해주세요!

## 📝 리뷰 요청
- DB에 업데이트하고 실패하면서 트러블 슈팅의 결과 변경된 내용들입니다. 크게 피드백할 건 없을 수도 있지만 데이터를 업로드하는 방식에 대해 질문 있으면 편하게 해주세요!
