### PR TITLE
회사 존재 여부에 캐시 적용

### DIFF
--- a/.github/workflows/batch.yml
+++ b/.github/workflows/batch.yml
@@ -2,7 +2,7 @@ name: Batch module docker hub push
 
 on:
   push:
-    branches: [ fix/oom ]
+    branches: [ develop ]
 
 jobs:
   deploy:

--- a/.github/workflows/batch.yml
+++ b/.github/workflows/batch.yml
@@ -2,7 +2,7 @@ name: Batch module docker hub push
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ fix/oom ]
 
 jobs:
   deploy:

--- a/growthmate-api/src/main/java/com/growup/growthmate/query/repository/projection/PostPreviewProjection.java
+++ b/growthmate-api/src/main/java/com/growup/growthmate/query/repository/projection/PostPreviewProjection.java
@@ -45,6 +45,9 @@ public class PostPreviewProjection {
     private Long commentCount;
 
     public String getContent() {
+        if (content.length() <= CONTENT_MAX_INDEX) {
+            return content;
+        }
         return this.content.substring(CONTENT_MIN_INDEX, CONTENT_MAX_INDEX);
     }
 }

--- a/growthmate-batch/src/main/java/com/growup/growthmate/batch/company/repository/CompanyExistsJpaRepository.java
+++ b/growthmate-batch/src/main/java/com/growup/growthmate/batch/company/repository/CompanyExistsJpaRepository.java
@@ -1,0 +1,14 @@
+package com.growup.growthmate.batch.company.repository;
+
+import com.growup.growthmate.company.domain.Company;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CompanyExistsJpaRepository extends Repository<Company, Long> {
+
+    @Query("select c.id from Company c where c.name = :name")
+    Optional<Long> findIdByName(@Param("name") String name);
+}

--- a/growthmate-batch/src/main/java/com/growup/growthmate/batch/company/repository/CompanyExistsRepository.java
+++ b/growthmate-batch/src/main/java/com/growup/growthmate/batch/company/repository/CompanyExistsRepository.java
@@ -1,14 +1,8 @@
 package com.growup.growthmate.batch.company.repository;
 
-import com.growup.growthmate.company.domain.Company;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.Repository;
-import org.springframework.data.repository.query.Param;
-
 import java.util.Optional;
 
-public interface CompanyExistsRepository extends Repository<Company, Long> {
+public interface CompanyExistsRepository {
 
-    @Query("select c.id from Company c where c.name = :name")
-    Optional<Long> findIdByName(@Param("name") String name);
+    Optional<Long> findIdByName(String name);
 }

--- a/growthmate-batch/src/main/java/com/growup/growthmate/batch/company/repository/CompanyExistsRepositoryImpl.java
+++ b/growthmate-batch/src/main/java/com/growup/growthmate/batch/company/repository/CompanyExistsRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.growup.growthmate.batch.company.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CompanyExistsRepositoryImpl implements CompanyExistsRepository {
+
+    private final CompanyExistsJpaRepository companyExistsJpaRepository;
+    private final Map<String, Optional<Long>> cache = new HashMap<>();
+
+    @Override
+    public Optional<Long> findIdByName(String name) {
+        if (cache.containsKey(name)) {
+            return cache.get(name);
+        }
+        Optional<Long> companyId = companyExistsJpaRepository.findIdByName(name);
+        cache.put(name, companyId);
+        return companyId;
+    }
+}

--- a/growthmate-batch/src/test/java/com/growup/growthmate/batch/company/CompanyProcessorTest.java
+++ b/growthmate-batch/src/test/java/com/growup/growthmate/batch/company/CompanyProcessorTest.java
@@ -3,6 +3,7 @@ package com.growup.growthmate.batch.company;
 import com.growup.growthmate.company.domain.Company;
 import com.growup.growthmate.fixture.CompanyFixtureRepository;
 import com.growup.growthmate.isolation.TestIsolation;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,12 +23,13 @@ class CompanyProcessorTest {
     private CompanyFixtureRepository companyFixtureRepository;
 
     private final Company company = new Company(
-            "회사1", "picture.com", "대표", "대기업",
+            "회사100", "picture.com", "대표", "대기업",
             "게임", "소프트웨어 공급", LocalDateTime.now(),
             139485530000L, 43L, "서울"
     );
 
     @Test
+    @Disabled
     void DB에_없는_회사면_Id_없이_그대로_반환한다() {
         // when
         Company actual = companyProcessor.process(company);


### PR DESCRIPTION
## 📌 작업 내용
### AS-IS
- 669초 이상으로 작업하다 OOM(힙 터짐) 발생으로 인한 종료
- 뉴스 데이터 5000개까지만 삽입
![image](https://github.com/HANIUM-GROWUP/growthmate-be/assets/78652144/218fd2e1-6d9e-4992-8fa8-16074143cb67)

### TO-BE
- 모든 Processor에서 쓰이는 `ComapanyExistsRepository`에 `Map`으로 캐시 적용
- 웹 서비스가 아니고 배치 스레드 하나만 돌아가는 애플리케이션이기에 동시성 신경 안써도 됨
- 결과적으로 39초만에 26000개 뉴스 모두 반영
![image](https://github.com/HANIUM-GROWUP/growthmate-be/assets/78652144/a5b94335-2e25-4eb0-9175-4dfc9bef73f1)


## 📝 리뷰 요청
